### PR TITLE
Fixed endianness on IPv4 and iPv6 struct packing

### DIFF
--- a/internal/wgnl/configure_linux.go
+++ b/internal/wgnl/configure_linux.go
@@ -213,7 +213,7 @@ func sockaddrBytes(endpoint net.UDPAddr) ([]byte, error) {
 
 		sa := unix.RawSockaddrInet6{
 			Family: unix.AF_INET6,
-			Port:   binary.BigEndian.Uint16(nlenc.Uint16Bytes(uint16(endpoint.Port))),
+			Port:   sockaddrPort(endpoint.Port),
 			Addr:   addr,
 		}
 
@@ -226,7 +226,7 @@ func sockaddrBytes(endpoint net.UDPAddr) ([]byte, error) {
 
 	sa := unix.RawSockaddrInet4{
 		Family: unix.AF_INET,
-		Port:   binary.BigEndian.Uint16(nlenc.Uint16Bytes(uint16(endpoint.Port))),
+		Port:   sockaddrPort(endpoint.Port),
 		Addr:   addr,
 	}
 
@@ -287,4 +287,10 @@ func isValidIP(ip net.IP) bool {
 // isIPv6 determines if IP is a valid IPv6 address.
 func isIPv6(ip net.IP) bool {
 	return isValidIP(ip) && ip.To4() == nil
+}
+
+// sockaddrPort interprets port as a big endian uint16 for use passing sockaddr
+// structures to the kernel.
+func sockaddrPort(port int) uint16 {
+	return binary.BigEndian.Uint16(nlenc.Uint16Bytes(uint16(port)))
 }

--- a/internal/wgnl/configure_linux_test.go
+++ b/internal/wgnl/configure_linux_test.go
@@ -3,6 +3,7 @@
 package wgnl
 
 import (
+	"encoding/binary"
 	"net"
 	"testing"
 	"time"
@@ -146,7 +147,7 @@ func TestLinuxClientConfigureDevice(t *testing.T) {
 											0x00, 0x00, 0x00, 0x00,
 											0x00, 0x00, 0x00, 0x33,
 										},
-										Port: 51820,
+										Port: binary.BigEndian.Uint16(nlenc.Uint16Bytes((51820))),
 									})))[:],
 								},
 								{
@@ -173,7 +174,7 @@ func TestLinuxClientConfigureDevice(t *testing.T) {
 									Data: (*(*[unix.SizeofSockaddrInet4]byte)(unsafe.Pointer(&unix.RawSockaddrInet4{
 										Family: unix.AF_INET,
 										Addr:   [4]byte{182, 122, 22, 19},
-										Port:   3233,
+										Port:   binary.BigEndian.Uint16(nlenc.Uint16Bytes(3233)),
 									})))[:],
 								},
 								{
@@ -205,7 +206,7 @@ func TestLinuxClientConfigureDevice(t *testing.T) {
 									Data: (*(*[unix.SizeofSockaddrInet4]byte)(unsafe.Pointer(&unix.RawSockaddrInet4{
 										Family: unix.AF_INET,
 										Addr:   [4]byte{5, 152, 198, 39},
-										Port:   51820,
+										Port:   binary.BigEndian.Uint16(nlenc.Uint16Bytes(51820)),
 									})))[:],
 								},
 								{

--- a/internal/wgnl/configure_linux_test.go
+++ b/internal/wgnl/configure_linux_test.go
@@ -147,7 +147,7 @@ func TestLinuxClientConfigureDevice(t *testing.T) {
 											0x00, 0x00, 0x00, 0x00,
 											0x00, 0x00, 0x00, 0x33,
 										},
-										Port: binary.BigEndian.Uint16(nlenc.Uint16Bytes((51820))),
+										Port: binary.BigEndian.Uint16(nlenc.Uint16Bytes(51820)),
 									})))[:],
 								},
 								{

--- a/internal/wgnl/configure_linux_test.go
+++ b/internal/wgnl/configure_linux_test.go
@@ -3,7 +3,6 @@
 package wgnl
 
 import (
-	"encoding/binary"
 	"net"
 	"testing"
 	"time"
@@ -147,7 +146,7 @@ func TestLinuxClientConfigureDevice(t *testing.T) {
 											0x00, 0x00, 0x00, 0x00,
 											0x00, 0x00, 0x00, 0x33,
 										},
-										Port: binary.BigEndian.Uint16(nlenc.Uint16Bytes(51820)),
+										Port: sockaddrPort(51820),
 									})))[:],
 								},
 								{
@@ -174,7 +173,7 @@ func TestLinuxClientConfigureDevice(t *testing.T) {
 									Data: (*(*[unix.SizeofSockaddrInet4]byte)(unsafe.Pointer(&unix.RawSockaddrInet4{
 										Family: unix.AF_INET,
 										Addr:   [4]byte{182, 122, 22, 19},
-										Port:   binary.BigEndian.Uint16(nlenc.Uint16Bytes(3233)),
+										Port:   sockaddrPort(3233),
 									})))[:],
 								},
 								{
@@ -206,7 +205,7 @@ func TestLinuxClientConfigureDevice(t *testing.T) {
 									Data: (*(*[unix.SizeofSockaddrInet4]byte)(unsafe.Pointer(&unix.RawSockaddrInet4{
 										Family: unix.AF_INET,
 										Addr:   [4]byte{5, 152, 198, 39},
-										Port:   binary.BigEndian.Uint16(nlenc.Uint16Bytes(51820)),
+										Port:   sockaddrPort(51820),
 									})))[:],
 								},
 								{

--- a/internal/wgnl/parse_linux.go
+++ b/internal/wgnl/parse_linux.go
@@ -3,6 +3,7 @@
 package wgnl
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net"
 	"time"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/mdlayher/genetlink"
 	"github.com/mdlayher/netlink"
+	"github.com/mdlayher/netlink/nlenc"
 	"github.com/mdlayher/wireguardctrl/internal/wgnl/internal/wgh"
 	"github.com/mdlayher/wireguardctrl/wgtypes"
 	"golang.org/x/sys/unix"
@@ -230,9 +232,11 @@ func parseSockaddr(endpoint *net.UDPAddr) func(b []byte) error {
 			// IPv4 address parsing.
 			sa := *(*unix.RawSockaddrInet4)(unsafe.Pointer(&b[0]))
 
+			fmt.Println()
+
 			*endpoint = net.UDPAddr{
 				IP:   net.IP(sa.Addr[:]).To4(),
-				Port: int(sa.Port),
+				Port: int(binary.BigEndian.Uint16(nlenc.Uint16Bytes(sa.Port))),
 			}
 
 			return nil
@@ -242,7 +246,7 @@ func parseSockaddr(endpoint *net.UDPAddr) func(b []byte) error {
 
 			*endpoint = net.UDPAddr{
 				IP:   net.IP(sa.Addr[:]),
-				Port: int(sa.Port),
+				Port: int(binary.BigEndian.Uint16(nlenc.Uint16Bytes(sa.Port))),
 			}
 
 			return nil

--- a/internal/wgnl/parse_linux.go
+++ b/internal/wgnl/parse_linux.go
@@ -3,7 +3,6 @@
 package wgnl
 
 import (
-	"encoding/binary"
 	"fmt"
 	"net"
 	"time"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/mdlayher/genetlink"
 	"github.com/mdlayher/netlink"
-	"github.com/mdlayher/netlink/nlenc"
 	"github.com/mdlayher/wireguardctrl/internal/wgnl/internal/wgh"
 	"github.com/mdlayher/wireguardctrl/wgtypes"
 	"golang.org/x/sys/unix"
@@ -232,11 +230,9 @@ func parseSockaddr(endpoint *net.UDPAddr) func(b []byte) error {
 			// IPv4 address parsing.
 			sa := *(*unix.RawSockaddrInet4)(unsafe.Pointer(&b[0]))
 
-			fmt.Println()
-
 			*endpoint = net.UDPAddr{
 				IP:   net.IP(sa.Addr[:]).To4(),
-				Port: int(binary.BigEndian.Uint16(nlenc.Uint16Bytes(sa.Port))),
+				Port: int(sockaddrPort(int(sa.Port))),
 			}
 
 			return nil
@@ -246,7 +242,7 @@ func parseSockaddr(endpoint *net.UDPAddr) func(b []byte) error {
 
 			*endpoint = net.UDPAddr{
 				IP:   net.IP(sa.Addr[:]),
-				Port: int(binary.BigEndian.Uint16(nlenc.Uint16Bytes(sa.Port))),
+				Port: int(sockaddrPort(int(sa.Port))),
 			}
 
 			return nil

--- a/internal/wgnl/parse_linux_test.go
+++ b/internal/wgnl/parse_linux_test.go
@@ -3,7 +3,6 @@
 package wgnl
 
 import (
-	"encoding/binary"
 	"net"
 	"testing"
 	"time"
@@ -210,7 +209,7 @@ func TestLinuxClientDevicesOK(t *testing.T) {
 										Type: wgh.PeerAEndpoint,
 										Data: (*(*[unix.SizeofSockaddrInet4]byte)(unsafe.Pointer(&unix.RawSockaddrInet4{
 											Addr: [4]byte{192, 168, 1, 1},
-											Port: binary.BigEndian.Uint16(nlenc.Uint16Bytes(1111)),
+											Port: sockaddrPort(1111),
 										})))[:],
 									},
 									{
@@ -259,7 +258,7 @@ func TestLinuxClientDevicesOK(t *testing.T) {
 												0x00, 0x00, 0x00, 0x00,
 												0x00, 0x00, 0x00, 0x01,
 											},
-											Port: binary.BigEndian.Uint16(nlenc.Uint16Bytes(2222)),
+											Port: sockaddrPort(2222),
 										})))[:],
 									},
 								}),

--- a/internal/wgnl/parse_linux_test.go
+++ b/internal/wgnl/parse_linux_test.go
@@ -3,6 +3,7 @@
 package wgnl
 
 import (
+	"encoding/binary"
 	"net"
 	"testing"
 	"time"
@@ -209,7 +210,7 @@ func TestLinuxClientDevicesOK(t *testing.T) {
 										Type: wgh.PeerAEndpoint,
 										Data: (*(*[unix.SizeofSockaddrInet4]byte)(unsafe.Pointer(&unix.RawSockaddrInet4{
 											Addr: [4]byte{192, 168, 1, 1},
-											Port: 1111,
+											Port: binary.BigEndian.Uint16(nlenc.Uint16Bytes(1111)),
 										})))[:],
 									},
 									{
@@ -258,7 +259,7 @@ func TestLinuxClientDevicesOK(t *testing.T) {
 												0x00, 0x00, 0x00, 0x00,
 												0x00, 0x00, 0x00, 0x01,
 											},
-											Port: 2222,
+											Port: binary.BigEndian.Uint16(nlenc.Uint16Bytes(2222)),
 										})))[:],
 									},
 								}),


### PR DESCRIPTION
Relates to #15.

This changes how you pack the structs for v4 and v6 addresses. Since some fields must be represented as BigEndian and some other as LittleEndian. I'm not sure if this is the proper way or if there was a way to keep your unsafe pointer method and still get to the same output.

You tell me.