### PR TITLE
wireguardctrl: treat UNIX epoch as zero time.Time

### DIFF
--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -174,7 +174,7 @@ func testConfigure(t *testing.T, c *wireguardctrl.Client, devices []*wgtypes.Dev
 			ListenPort: port,
 			Peers: []wgtypes.Peer{{
 				PublicKey:         peerKey,
-				LastHandshakeTime: time.Unix(0, 0),
+				LastHandshakeTime: time.Time{},
 				AllowedIPs:        ips,
 				ProtocolVersion:   1,
 			}},

--- a/internal/wgnl/parse_linux.go
+++ b/internal/wgnl/parse_linux.go
@@ -270,7 +270,12 @@ func parseTimespec(t *time.Time) func(b []byte) error {
 		// architectures, so an explicit conversion to int64 is required, even
 		// though it isn't needed on amd64.
 		ts := *(*unix.Timespec)(unsafe.Pointer(&b[0]))
-		*t = time.Unix(int64(ts.Sec), int64(ts.Nsec))
+
+		// Only set fields if UNIX timestamp value is greater than 0, so the
+		// caller will see a zero-value time.Time otherwise.
+		if ts.Sec > 0 && ts.Nsec > 0 {
+			*t = time.Unix(int64(ts.Sec), int64(ts.Nsec))
+		}
 
 		return nil
 	}

--- a/internal/wgnl/parse_linux_test.go
+++ b/internal/wgnl/parse_linux_test.go
@@ -246,8 +246,7 @@ func TestLinuxClientDevicesOK(t *testing.T) {
 									},
 								}),
 							},
-							// "dummy" peer with only necessary fields to verify
-							// multi-peer parsing logic and IPv4/IPv6 parsing.
+							// "dummy" peer with only some necessary fields.
 							{
 								Type: 1,
 								Data: nltest.MustMarshalAttributes([]netlink.Attribute{
@@ -265,6 +264,16 @@ func TestLinuxClientDevicesOK(t *testing.T) {
 												0x00, 0x00, 0x00, 0x01,
 											},
 											Port: sockaddrPort(2222),
+										})))[:],
+									},
+									// Explicitly set last handshake time to
+									// UNIX timestamp 0 to test zero-value
+									// time.Time logic.
+									{
+										Type: wgh.PeerALastHandshakeTime,
+										Data: (*(*[sizeofTimespec]byte)(unsafe.Pointer(&unix.Timespec{
+											Sec:  0,
+											Nsec: 0,
 										})))[:],
 									},
 								}),

--- a/internal/wguser/parse.go
+++ b/internal/wguser/parse.go
@@ -154,10 +154,12 @@ func (dp *deviceParser) peerParse(key, value string) {
 		dp.hsNano = dp.parseInt(value)
 
 		// Assume that we've seen both seconds and nanoseconds and populate this
-		// field now.
-		//
-		// TODO(mdlayher): verify validity of assuming ordering with this approach.
-		p.LastHandshakeTime = time.Unix(int64(dp.hsSec), int64(dp.hsNano))
+		// field now. However, if both fields were set to 0, assume we have never
+		// had a successful handshake with this peer, and return a zero-value
+		// time.Time to our callers.
+		if dp.hsSec > 0 && dp.hsNano > 0 {
+			p.LastHandshakeTime = time.Unix(int64(dp.hsSec), int64(dp.hsNano))
+		}
 	case "tx_bytes":
 		p.TransmitBytes = dp.parseInt64(value)
 	case "rx_bytes":

--- a/internal/wguser/parse_test.go
+++ b/internal/wguser/parse_test.go
@@ -26,8 +26,12 @@ rx_bytes=2224
 allowed_ip=192.168.4.6/32
 persistent_keepalive_interval=111
 endpoint=182.122.22.19:3233
+last_handshake_time_sec=0
+last_handshake_time_nsec=0
 public_key=662e14fd594556f522604703340351258903b64f35553763f19426ab2a515c58
 endpoint=5.152.198.39:51820
+last_handshake_time_sec=0
+last_handshake_time_nsec=0
 allowed_ip=192.168.4.10/32
 allowed_ip=192.168.4.11/32
 tx_bytes=1212111
@@ -109,6 +113,9 @@ func TestClientDevices(t *testing.T) {
 							IP:   net.IPv4(182, 122, 22, 19),
 							Port: 3233,
 						},
+						// Zero-value because UNIX timestamp of 0. Explicitly
+						// set for documentation purposes here.
+						LastHandshakeTime:           time.Time{},
 						PersistentKeepaliveInterval: 111000000000,
 						ReceiveBytes:                2224,
 						TransmitBytes:               38333,


### PR DESCRIPTION
I think this makes more sense than asking the caller to check for `time.Unix(0, 0)` for "last handshake never occurred".

Fixes #24.

/r @cespare