### PR TITLE
internal/wguser: initial support for Windows

### DIFF
--- a/cmd/wgctrl/main.go
+++ b/cmd/wgctrl/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -13,15 +14,27 @@ import (
 )
 
 func main() {
+	flag.Parse()
+
 	c, err := wireguardctrl.New()
 	if err != nil {
 		log.Fatalf("failed to open wireguardctrl: %v", err)
 	}
 	defer c.Close()
 
-	devices, err := c.Devices()
-	if err != nil {
-		log.Fatalf("failed to get devices: %v", err)
+	var devices []*wgtypes.Device
+	if device := flag.Arg(0); device != "" {
+		d, err := c.Device(device)
+		if err != nil {
+			log.Fatalf("failed to get device %q: %v", device, err)
+		}
+
+		devices = append(devices, d)
+	} else {
+		devices, err = c.Devices()
+		if err != nil {
+			log.Fatalf("failed to get devices: %v", err)
+		}
 	}
 
 	for _, d := range devices {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.2.0
 	github.com/mdlayher/genetlink v0.0.0-20190419142426-b806ce69960a
 	github.com/mdlayher/netlink v0.0.0-20190419142405-71c9566a34ae
+	github.com/microsoft/go-winio v0.4.12
 	github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721
 	golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480
 	golang.org/x/sys v0.0.0-20190418153312-f0ce4c0180be

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/mdlayher/genetlink v0.0.0-20190419142426-b806ce69960a h1:tIPUNU99ot2T
 github.com/mdlayher/genetlink v0.0.0-20190419142426-b806ce69960a/go.mod h1:J+g63IQCVwjKLOxodrxOylt23f7d5vVB9rgNh+T13Uk=
 github.com/mdlayher/netlink v0.0.0-20190419142405-71c9566a34ae h1:Ec6B7pKh4YZyKI9VtTeZmN1GGLvAIT/fs2votDcWnMU=
 github.com/mdlayher/netlink v0.0.0-20190419142405-71c9566a34ae/go.mod h1:TR9n0u8mie4+iszGTMjP6QRwUZQNynkhDbXTLF6DUi4=
+github.com/microsoft/go-winio v0.4.12 h1:3vDRRsUnj2dKE7QKoedntu9hbuD8gzaVd2E2UZioqx4=
+github.com/microsoft/go-winio v0.4.12/go.mod h1:kcIxxtKZE55DEncT/EOvFiygPobhUWpSDqDb47poQOU=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 h1:RlZweED6sbSArvlE924+mUcZuXKLBHA35U7LN621Bws=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721/go.mod h1:Ickgr2WtCLZ2MDGd4Gr0geeCH5HybhRJbonOgQpvSxc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/wguser/client_test.go
+++ b/internal/wguser/client_test.go
@@ -59,44 +59,6 @@ func TestClientDevice(t *testing.T) {
 	}
 }
 
-func Test_findSocketFiles(t *testing.T) {
-	tmp, err := ioutil.TempDir(os.TempDir(), "wireguardcfg-test")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tmp)
-
-	// Create a file which is not a device socket.
-	f, err := ioutil.TempFile(tmp, "notwg")
-	if err != nil {
-		t.Fatalf("failed to create temporary file: %v", err)
-	}
-	_ = f.Close()
-
-	// Create a temporary UNIX socket and leave it open so it is picked up
-	// as a socket file.
-	path := filepath.Join(tmp, "testwg0.sock")
-	l, err := net.Listen("unix", path)
-	if err != nil {
-		t.Fatalf("failed to create socket: %v", err)
-	}
-	defer l.Close()
-
-	files, err := findSocketFiles([]string{
-		tmp,
-		// Should gracefully handle non-existent directories and files.
-		filepath.Join(tmp, "foo"),
-		"/not/exist",
-	})
-	if err != nil {
-		t.Fatalf("failed to find files: %v", err)
-	}
-
-	if diff := cmp.Diff([]string{path}, files); diff != "" {
-		t.Fatalf("unexpected output files (-want +got):\n%s", diff)
-	}
-}
-
 func testClient(t *testing.T, res []byte) (*Client, func() []byte) {
 	tmp, err := ioutil.TempDir(os.TempDir(), "wireguardcfg-test")
 	if err != nil {
@@ -152,8 +114,11 @@ func testClient(t *testing.T, res []byte) (*Client, func() []byte) {
 	}()
 
 	c := &Client{
-		findSockets: func() ([]string, error) {
+		find: func() ([]string, error) {
 			return []string{path}, nil
+		},
+		dial: func(device string) (net.Conn, error) {
+			return net.Dial("unix", device)
 		},
 	}
 

--- a/internal/wguser/configure.go
+++ b/internal/wguser/configure.go
@@ -5,20 +5,19 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"strings"
 
 	"github.com/mdlayher/wireguardctrl/wgtypes"
 )
 
-// configureDevice configures the device at the UNIX socket specified by path.
-func configureDevice(path string, cfg wgtypes.Config) error {
-	c, err := net.Dial("unix", path)
+// configureDevice configures a device specified by its path.
+func (c *Client) configureDevice(device string, cfg wgtypes.Config) error {
+	conn, err := c.dial(device)
 	if err != nil {
 		return err
 	}
-	defer c.Close()
+	defer conn.Close()
 
 	// Start with set command.
 	var buf bytes.Buffer
@@ -29,12 +28,12 @@ func configureDevice(path string, cfg wgtypes.Config) error {
 	buf.WriteString("\n")
 
 	// Apply configuration for the device and then check the error number.
-	if _, err := io.Copy(c, &buf); err != nil {
+	if _, err := io.Copy(conn, &buf); err != nil {
 		return err
 	}
 
 	res := make([]byte, 32)
-	n, err := c.Read(res)
+	n, err := conn.Read(res)
 	if err != nil {
 		return err
 	}

--- a/internal/wguser/conn_unix.go
+++ b/internal/wguser/conn_unix.go
@@ -1,0 +1,49 @@
+//+build !windows
+
+package wguser
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+// dial is the default implementation of Client.dial.
+func dial(device string) (net.Conn, error) {
+	return net.Dial("unix", device)
+}
+
+// find is the default implementation of Client.find.
+func find() ([]string, error) {
+	return findUNIXSockets([]string{
+		// It seems that /var/run is a common location between Linux and the
+		// BSDs, even though it's a symlink on Linux.
+		"/var/run/wireguard",
+	})
+}
+
+// findUNIXSockets looks for UNIX socket files in the specified directories.
+func findUNIXSockets(dirs []string) ([]string, error) {
+	var socks []string
+	for _, d := range dirs {
+		files, err := ioutil.ReadDir(d)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+
+			return nil, err
+		}
+
+		for _, f := range files {
+			if f.Mode()&os.ModeSocket == 0 {
+				continue
+			}
+
+			socks = append(socks, filepath.Join(d, f.Name()))
+		}
+	}
+
+	return socks, nil
+}

--- a/internal/wguser/conn_unix_test.go
+++ b/internal/wguser/conn_unix_test.go
@@ -1,0 +1,51 @@
+//+build !windows
+
+package wguser
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestUNIX_findUNIXSockets(t *testing.T) {
+	tmp, err := ioutil.TempDir(os.TempDir(), "wireguardcfg-test")
+	if err != nil {
+		t.Fatalf("failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	// Create a file which is not a device socket.
+	f, err := ioutil.TempFile(tmp, "notwg")
+	if err != nil {
+		t.Fatalf("failed to create temporary file: %v", err)
+	}
+	_ = f.Close()
+
+	// Create a temporary UNIX socket and leave it open so it is picked up
+	// as a socket file.
+	path := filepath.Join(tmp, "testwg0.sock")
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("failed to create socket: %v", err)
+	}
+	defer l.Close()
+
+	files, err := findUNIXSockets([]string{
+		tmp,
+		// Should gracefully handle non-existent directories and files.
+		filepath.Join(tmp, "foo"),
+		"/not/exist",
+	})
+	if err != nil {
+		t.Fatalf("failed to find files: %v", err)
+	}
+
+	if diff := cmp.Diff([]string{path}, files); diff != "" {
+		t.Fatalf("unexpected output files (-want +got):\n%s", diff)
+	}
+}

--- a/internal/wguser/conn_windows.go
+++ b/internal/wguser/conn_windows.go
@@ -1,0 +1,62 @@
+//+build windows
+
+package wguser
+
+import (
+	"net"
+	"strings"
+
+	winio "github.com/microsoft/go-winio"
+	"golang.org/x/sys/windows"
+)
+
+// Expected prefixes when dealing with named pipes.
+const (
+	pipePrefix = `\\.\pipe\`
+	wgPrefix   = `WireGuard\`
+)
+
+// dial is the default implementation of Client.dial.
+func dial(device string) (net.Conn, error) {
+	return winio.DialPipe(device, nil)
+}
+
+// find is the default implementation of Client.find.
+func find() ([]string, error) {
+	var (
+		pipes []string
+		data  windows.Win32finddata
+	)
+
+	// Thanks @zx2c4 for the tips on the appropriate Windows APIs here:
+	// https://א.cc/dHGpnhxX/c.
+	h, err := windows.FindFirstFile(
+		// Append * to find all named pipes.
+		windows.StringToUTF16Ptr(pipePrefix+"*"),
+		&data,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check the first file's name for a match, but also keep searching for
+	// WireGuard named pipes until no more files can be iterated.
+	for {
+		name := windows.UTF16ToString(data.FileName[:])
+		if strings.HasPrefix(name, wgPrefix) {
+			// Concatenate strings directly as filepath.Join appears to break the
+			// named pipe prefix convention.
+			pipes = append(pipes, pipePrefix+name)
+		}
+
+		if err := windows.FindNextFile(h, &data); err != nil {
+			if err == windows.ERROR_NO_MORE_FILES {
+				break
+			}
+
+			return nil, err
+		}
+	}
+
+	return pipes, nil
+}

--- a/internal/wguser/parse.go
+++ b/internal/wguser/parse.go
@@ -17,28 +17,28 @@ import (
 // The WireGuard userspace configuration protocol is described here:
 // https://www.wireguard.com/xplatform/#cross-platform-userspace-implementation.
 
-// getDevice gathers device information from the UNIX socket specified by path
+// getDevice gathers device information from a device specified by its path
 // and returns a Device.
-func getDevice(path string) (*wgtypes.Device, error) {
-	c, err := net.Dial("unix", path)
+func (c *Client) getDevice(device string) (*wgtypes.Device, error) {
+	conn, err := c.dial(device)
 	if err != nil {
 		return nil, err
 	}
-	defer c.Close()
+	defer conn.Close()
 
 	// Get information about this device.
-	if _, err := io.WriteString(c, "get=1\n\n"); err != nil {
+	if _, err := io.WriteString(conn, "get=1\n\n"); err != nil {
 		return nil, err
 	}
 
 	// Parse the device from the incoming data stream.
-	d, err := parseDevice(c)
+	d, err := parseDevice(conn)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO(mdlayher): populate interface index too?
-	d.Name = deviceName(path)
+	d.Name = deviceName(device)
 	d.Type = wgtypes.Userspace
 
 	return d, nil


### PR DESCRIPTION
The first steps toward Windows support. We can find and attempt to connect to named pipes, but some more work will be necessary to actually allow accessing them:

```
matt@DESKTOP-2G8V6U5 C:\Users\matt\wireguardctrl\cmd\wgctrl>go build

matt@DESKTOP-2G8V6U5 C:\Users\matt\wireguardctrl\cmd\wgctrl>wgctrl.exe
2019/05/12 12:43:59 failed to get devices: open \\.\pipe\WireGuard\wgwindows0: Access is denied.

matt@DESKTOP-2G8V6U5 C:\Users\matt\wireguardctrl\cmd\wgctrl>wgctrl.exe wgwindows0
2019/05/12 12:44:02 failed to get device "wgwindows0": open \\.\pipe\WireGuard\wgwindows0: Access is denied.

```